### PR TITLE
feat: Implement image analysis from local file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # image-mcp-server
 
-画像のURLを受け取り、GPT-4o-miniモデルを使用して画像の内容を分析するMCPサーバーです。
+画像URLまたはローカルファイルパスを受け取り、GPT-4o-miniモデルを使用して画像の内容を分析するMCPサーバーです。
 
 ## 機能
 
-- 画像URLを入力として受け取り、その画像の内容を詳細に分析
+- 画像URLまたはローカルファイルパスを入力として受け取り、その画像の内容を詳細に分析
 - GPT-4o-miniモデルを使用した高精度な画像認識と説明
 - 画像URLの有効性チェック機能
+- ローカルファイルからの画像読み込みとBase64エンコード
 
 ## インストール
 
 ```bash
 # リポジトリをクローン
-git clone https://github.com/champierre/image-mcp-server.git
+git clone https://github.com/champierre/image-mcp-server.git # またはForkしたリポジトリ
 cd image-mcp-server
 
 # 依存パッケージのインストール
@@ -78,12 +79,48 @@ Clineなどのツールで使用するには、MCPサーバー設定ファイル
 
 MCPサーバーが設定されると、以下のツールが利用可能になります：
 
-- `analyze_image`: 画像URLを受け取り、その内容を分析します
+- `analyze_image`: 画像URLを受け取り、その内容を分析します。
+- `analyze_image_from_path`: ローカルファイルパスを受け取り、その内容を分析します。
 
 ### 使用例
 
+**URLから分析:**
 ```
 画像URLを分析してください: https://example.com/image.jpg
+```
+
+**ローカルファイルパスから分析:**
+```
+この画像を分析してください: /path/to/your/image.jpg
+```
+
+### 注意: ローカルファイルパスの指定について
+
+`analyze_image_from_path` ツールを使用する場合、AIアシスタント（クライアント）は、**このサーバーが実行されている環境で有効なファイルパス**を指定する必要があります。
+
+- **サーバーがWSL上で実行されている場合:**
+  - AIアシスタントがWindowsパス（例: `C:\...`）を持っている場合、それをWSLパス（例: `/mnt/c/...`）に変換してからツールに渡す必要があります。
+  - AIアシスタントがWSLパスを持っている場合は、そのまま渡します。
+- **サーバーがWindows上で実行されている場合:**
+  - AIアシスタントがWSLパス（例: `/home/user/...`）を持っている場合、それをUNCパス（例: `\\wsl$\Distro\...`）に変換してからツールに渡す必要があります。
+  - AIアシスタントがWindowsパスを持っている場合は、そのまま渡します。
+
+**パス変換はAIアシスタント（またはその実行環境）の責任範囲となります。** サーバーは受け取ったパスをそのまま解釈しようとします。
+
+### 注意: ビルド時の型エラーについて
+
+`npm run build` を実行する際、`mime-types` モジュールに関するTypeScriptの型定義ファイルが見つからない旨のエラー (TS7016) が表示される場合があります。
+
+```
+src/index.ts:16:23 - error TS7016: Could not find a declaration file for module 'mime-types'. ...
+```
+
+これは型チェックのエラーであり、JavaScriptへのコンパイル自体は成功しているため、**サーバーの実行には影響ありません**。このエラーを解消したい場合は、開発依存関係として型定義ファイルをインストールしてください。
+
+```bash
+npm install --save-dev @types/mime-types
+# または
+yarn add --dev @types/mime-types
 ```
 
 ## 開発

--- a/package.json
+++ b/package.json
@@ -26,8 +26,12 @@
     "@types/node": "^22.13.13",
     "axios": "^1.8.4",
     "dotenv": "^16.4.7",
+    "mime-types": "^3.0.1",
     "openai": "^4.89.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.2"
+  },
+  "devDependencies": {
+    "@types/mime-types": "^2.1.4"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,10 @@ import {
 import { OpenAI } from 'openai';
 import axios from 'axios';
 import * as dotenv from 'dotenv';
+import * as fs from 'fs'; // Import fs for file reading
+import * as path from 'path'; // Import path for path operations
+import * as os from 'os'; // Import os module
+import * as mime from 'mime-types'; // Revert to import statement
 
 // .envファイルから環境変数を読み込む
 dotenv.config();
@@ -25,13 +29,21 @@ const openai = new OpenAI({
   apiKey: OPENAI_API_KEY,
 });
 
-// 画像URLの引数の型チェック
+// --- Argument Type Guards ---
 const isValidAnalyzeImageArgs = (
   args: any
 ): args is { imageUrl: string } =>
   typeof args === 'object' &&
   args !== null &&
   typeof args.imageUrl === 'string';
+
+const isValidAnalyzeImagePathArgs = (
+  args: any
+): args is { imagePath: string } => // New type guard for path tool
+  typeof args === 'object' &&
+  args !== null &&
+  typeof args.imagePath === 'string';
+// --- End Argument Type Guards ---
 
 class ImageAnalysisServer {
   private server: Server;
@@ -40,7 +52,7 @@ class ImageAnalysisServer {
     this.server = new Server(
       {
         name: 'image-analysis-server',
-        version: '1.0.0',
+        version: '1.1.0', // Version bump
       },
       {
         capabilities: {
@@ -50,7 +62,7 @@ class ImageAnalysisServer {
     );
 
     this.setupToolHandlers();
-    
+
     // エラーハンドリング
     this.server.onerror = (error) => console.error('[MCP Error]', error);
     process.on('SIGINT', async () => {
@@ -77,34 +89,82 @@ class ImageAnalysisServer {
             required: ['imageUrl'],
           },
         },
+        // --- New Tool Definition ---
+        {
+          name: 'analyze_image_from_path',
+          description: 'ローカルファイルパスを受け取り、GPT-4o-miniを使用して画像の内容を分析します (サーバー実行環境からのアクセス)',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              imagePath: {
+                type: 'string',
+                description: '分析する画像のローカルファイルパス (サーバーからアクセス可能なパス)',
+              },
+            },
+            required: ['imagePath'],
+          },
+        },
+        // --- End New Tool Definition ---
       ],
     }));
 
     // ツール実行ハンドラ
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
-      if (request.params.name !== 'analyze_image') {
-        throw new McpError(
-          ErrorCode.MethodNotFound,
-          `Unknown tool: ${request.params.name}`
-        );
-      }
-
-      if (!isValidAnalyzeImageArgs(request.params.arguments)) {
-        throw new McpError(
-          ErrorCode.InvalidParams,
-          'Invalid arguments: imageUrl is required and must be a string'
-        );
-      }
-
-      const imageUrl = request.params.arguments.imageUrl;
+      const toolName = request.params.name;
+      const args = request.params.arguments;
 
       try {
-        // 画像URLが有効かチェック
-        await this.validateImageUrl(imageUrl);
-        
-        // GPT-4o-miniで画像を分析
-        const analysis = await this.analyzeImageWithGpt4(imageUrl);
+        let analysis: string;
 
+        if (toolName === 'analyze_image') {
+          if (!isValidAnalyzeImageArgs(args)) {
+            throw new McpError(
+              ErrorCode.InvalidParams,
+              'Invalid arguments for analyze_image: imageUrl (string) is required'
+            );
+          }
+          const imageUrl = args.imageUrl;
+          await this.validateImageUrl(imageUrl); // Validate URL accessibility
+          analysis = await this.analyzeImageWithGpt4({ type: 'url', data: imageUrl });
+
+        } else if (toolName === 'analyze_image_from_path') {
+          if (!isValidAnalyzeImagePathArgs(args)) {
+            throw new McpError(
+              ErrorCode.InvalidParams,
+              'Invalid arguments for analyze_image_from_path: imagePath (string) is required'
+            );
+          }
+          const imagePath = args.imagePath;
+          // Basic security check: prevent absolute paths trying to escape common roots (adjust as needed)
+          // This is a VERY basic check and might need refinement based on security requirements.
+          if (path.isAbsolute(imagePath) && !imagePath.startsWith(process.cwd()) && !imagePath.startsWith(os.homedir()) && !imagePath.startsWith('/mnt/')) {
+             // Allow relative paths, paths within cwd, home, or WSL mounts. Adjust if needed.
+             console.warn(`Potential unsafe path access attempt blocked: ${imagePath}`);
+             throw new McpError(ErrorCode.InvalidParams, 'Invalid or potentially unsafe imagePath provided.');
+          }
+
+          const resolvedPath = path.resolve(imagePath); // Resolve relative paths
+          if (!fs.existsSync(resolvedPath)) {
+            throw new McpError(ErrorCode.InvalidParams, `File not found at path: ${resolvedPath}`);
+          }
+          const imageDataBuffer = fs.readFileSync(resolvedPath);
+          const base64String = imageDataBuffer.toString('base64');
+          const mimeType = mime.lookup(resolvedPath) || 'application/octet-stream'; // Detect MIME type or default
+
+          if (!mimeType.startsWith('image/')) {
+             throw new McpError(ErrorCode.InvalidParams, `File is not an image: ${mimeType}`);
+          }
+
+          analysis = await this.analyzeImageWithGpt4({ type: 'base64', data: base64String, mimeType: mimeType });
+
+        } else {
+          throw new McpError(
+            ErrorCode.MethodNotFound,
+            `Unknown tool: ${toolName}`
+          );
+        }
+
+        // Return successful analysis
         return {
           content: [
             {
@@ -113,13 +173,15 @@ class ImageAnalysisServer {
             },
           ],
         };
+
       } catch (error) {
-        console.error('Error analyzing image:', error);
+        console.error(`Error calling tool ${toolName}:`, error);
+        // Return error content
         return {
           content: [
             {
               type: 'text',
-              text: `画像分析エラー: ${error instanceof Error ? error.message : String(error)}`,
+              text: `ツール実行エラー (${toolName}): ${error instanceof Error ? error.message : String(error)}`,
             },
           ],
           isError: true,
@@ -128,26 +190,35 @@ class ImageAnalysisServer {
     });
   }
 
-  // 画像URLが有効かチェックするメソッド
+  // 画像URLが有効かチェックするメソッド (既存)
   private async validateImageUrl(url: string): Promise<void> {
     try {
       const response = await axios.head(url);
       const contentType = response.headers['content-type'];
-      
       if (!contentType || !contentType.startsWith('image/')) {
-        throw new Error(`URLが画像ではありません: ${contentType}`);
+        throw new Error(`URL is not an image: ${contentType}`);
       }
     } catch (error) {
       if (axios.isAxiosError(error)) {
-        throw new Error(`画像URLにアクセスできません: ${error.message}`);
+        throw new Error(`Cannot access image URL: ${error.message}`);
       }
       throw error;
     }
   }
 
-  // GPT-4o-miniで画像を分析するメソッド
-  private async analyzeImageWithGpt4(imageUrl: string): Promise<string> {
+  // GPT-4o-miniで画像を分析するメソッド (修正: URLまたはBase64を受け取る)
+  private async analyzeImageWithGpt4(
+     imageData: { type: 'url', data: string } | { type: 'base64', data: string, mimeType: string }
+   ): Promise<string> {
     try {
+      let imageInput: any;
+      if (imageData.type === 'url') {
+        imageInput = { type: 'image_url', image_url: { url: imageData.data } };
+      } else {
+        // Construct data URI for OpenAI API
+        imageInput = { type: 'image_url', image_url: { url: `data:${imageData.mimeType};base64,${imageData.data}` } };
+      }
+
       const response = await openai.chat.completions.create({
         model: 'gpt-4o-mini',
         messages: [
@@ -159,7 +230,7 @@ class ImageAnalysisServer {
             role: 'user',
             content: [
               { type: 'text', text: '以下の画像を分析して、内容を詳しく説明してください。' },
-              { type: 'image_url', image_url: { url: imageUrl } },
+              imageInput, // Use the constructed image input
             ],
           },
         ],
@@ -176,7 +247,7 @@ class ImageAnalysisServer {
   async run() {
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
-    console.error('Image Analysis MCP server running on stdio');
+    console.error('Image Analysis MCP server (v1.1.0) running on stdio'); // Updated version
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,13 +92,13 @@ class ImageAnalysisServer {
         // --- New Tool Definition ---
         {
           name: 'analyze_image_from_path',
-          description: 'ローカルファイルパスを受け取り、GPT-4o-miniを使用して画像の内容を分析します (サーバー実行環境からのアクセス)',
+          description: 'ローカルファイルパスから画像を読み込み、GPT-4o-miniを使用して内容を分析します。AIアシスタントはサーバーの実行環境で有効なパスを渡す必要があります（例: WSL上のサーバーならLinuxパス）。',
           inputSchema: {
             type: 'object',
             properties: {
               imagePath: {
                 type: 'string',
-                description: '分析する画像のローカルファイルパス (サーバーからアクセス可能なパス)',
+                description: '分析する画像のローカルファイルパス（サーバー実行環境からアクセス可能な形式で指定）',
               },
             },
             required: ['imagePath'],


### PR DESCRIPTION
This pull request adds a new tool, `analyze_image_from_path`, to the image-mcp-server. 
This tool enables the server to analyze images from local file paths, enhancing its functionality and integration with other MCP servers.
The implementation includes reading the file, Base64 encoding it, and sending it to the OpenAI API for analysis. 
The README has also been updated to reflect these changes and provide clear usage instructions.
**Please review and let me know if you have any questions or suggestions. Thank you for your time and effort!**